### PR TITLE
Implement kill-streak and respawn mechanics

### DIFF
--- a/__tests__/core/GameState.test.js
+++ b/__tests__/core/GameState.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+import { GameState } from '../../core/GameState.js';
+import { Projectile } from '../../entities/Projectile.js';
+import { jest } from '@jest/globals';
+
+describe('player kill and respawn', () => {
+  test('hit increments shooter streak and respawns target', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const gs = new GameState();
+    globalThis.gameState = gs;
+    gs.grid.getRandomSpawn = jest.fn(() => ({ gx: 5, gy: 5 }));
+
+    const shooter = gs.player;
+    shooter.playerId = 'shooter';
+    const target = gs.addRemotePlayer('target');
+    target.shieldCooldown = 1; // can't block
+
+    target.gridX = 0;
+    target.gridY = 0;
+    target.updateWorldPos();
+
+    const proj = new Projectile(target.worldX, target.worldY, 0, shooter.playerId);
+    proj.update = () => false; // stay in place
+
+    gs.projectiles.push(proj);
+    gs.update();
+
+    expect(shooter.killStreak).toBe(1);
+    expect(target.killStreak).toBe(0);
+    expect(target.gridX).toBe(5);
+    expect(target.gridY).toBe(5);
+    Math.random.mockRestore();
+  });
+});

--- a/core/GameState.js
+++ b/core/GameState.js
@@ -81,6 +81,7 @@ export class GameState {
         // Attach combat state to human player
         this.player.shieldCooldown = 0;
         this.player.hitBlinkTimer = 0;
+        this.player.killStreak = 0;
 
         this.npcPlayers = [];
         this.otherPlayers = new Map();
@@ -97,6 +98,7 @@ export class GameState {
         pl.playerId = id;
         pl.shieldCooldown = 0;
         pl.hitBlinkTimer = 0;
+        pl.killStreak = 0;
         this.otherPlayers.set(id, pl);
         return pl;
     }
@@ -155,6 +157,14 @@ export class GameState {
                 if (distSq <= cubeRadius * cubeRadius) {
                     pl.hitBlinkTimer = 30; // blink for half a second
                     remove = true;
+                    const shooter = allPlayers.find(p => p.playerId === proj.shooterId);
+                    if (shooter) {
+                        shooter.killStreak = (shooter.killStreak || 0) + 1;
+                    }
+                    pl.killStreak = 0;
+                    if (typeof pl.respawn === 'function') {
+                        pl.respawn();
+                    }
                     break;
                 }
             }

--- a/entities/Grid.js
+++ b/entities/Grid.js
@@ -38,4 +38,12 @@ export class Grid {
     getWorldHalf() {
         return this.worldSize / 2;
     }
-} 
+
+    getRandomSpawn() {
+        const keys = Array.from(this.tiles.keys());
+        if (keys.length === 0) return { gx: 0, gy: 0 };
+        const idx = Math.floor(Math.random() * keys.length);
+        const [gx, gy] = keys[idx].split(',').map(Number);
+        return { gx, gy };
+    }
+}

--- a/entities/Player.js
+++ b/entities/Player.js
@@ -8,6 +8,7 @@ export class Player {
         this.worldY = 0;
         this.heading = -Math.PI / 2;
         this.heldOrb = false;
+        this.killStreak = 0;
         // Wait for next tick to update position to ensure gameState is available
         setTimeout(() => this.updateWorldPos(), 0);
     }
@@ -34,6 +35,15 @@ export class Player {
 
     rotate(direction) {
         this.heading += (Math.PI / 2) * direction;
+    }
+
+    respawn() {
+        const grid = globalThis.gameState.grid;
+        if (!grid || typeof grid.getRandomSpawn !== 'function') return;
+        const { gx, gy } = grid.getRandomSpawn();
+        this.gridX = gx;
+        this.gridY = gy;
+        this.updateWorldPos();
     }
 
     interact() {


### PR DESCRIPTION
## Summary
- add `killStreak` tracking on all players
- introduce `respawn()` method with random spawn logic
- update grid with `getRandomSpawn()` helper
- reset kill streak on death and increment attacker streak
- add Jest tests for new functionality

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_686c49d1e2fc8326b3a88e684c7156b0