### PR TITLE
Implement authoritative game rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ Game.render() → Camera transforms → Draw world → Draw UI
 4. **Draw Entities**: Render players and projectiles
 5. **Screen Space**: Draw UI elements (held balls, stats)
 
+## Authoritative State & Rooms
+
+All combat, scoring and projectile logic now runs on the server. Clients simply
+send input actions and render snapshots received via `state:update` events. Each
+connection joins a `GameRoom` which maintains its own `ServerGameState`.
+
+The maximum number of players per room is controlled by the `ROOM_CAP`
+environment variable (default `20`). On platforms like Render.com you can scale
+by running multiple instances with appropriate `ROOM_CAP` values.
+
 ## Development
 
 ### Adding New Features

--- a/__tests__/server/killLogic.test.js
+++ b/__tests__/server/killLogic.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import { jest } from '@jest/globals';
+import { GameRoom } from '../../core/GameRoom.js';
+import { Player } from '../../entities/Player.js';
+import { Projectile } from '../../entities/Projectile.js';
+
+function createMockIO() {
+  const emit = jest.fn();
+  return {
+    to: jest.fn(() => ({ emit })),
+  };
+}
+
+describe('server kill logic', () => {
+  test('projectile kills target and increments streak', () => {
+    jest.useFakeTimers();
+    const io = createMockIO();
+    const room = new GameRoom({ io, roomId: 'r1' });
+
+    globalThis.gameState = room.state;
+
+    const shooter = new Player(0, 0);
+    shooter.playerId = 'p1';
+    const target = new Player(0, 0);
+    target.playerId = 'p2';
+
+    room.state.players.set('p1', shooter);
+    room.state.players.set('p2', target);
+    room.state.leaderboard.set('p1', { kills: 0, streak: 0 });
+    room.state.leaderboard.set('p2', { kills: 0, streak: 0 });
+
+    const proj = new Projectile(target.worldX, target.worldY, 0, 'p1');
+    proj.update = () => false;
+    room.state.projectiles.set('proj1', proj);
+
+    jest.runAllTimers();
+
+    room.loop();
+
+    expect(room.state.leaderboard.get('p1').streak).toBe(1);
+    const innerEmit = io.to.mock.results[0].value.emit;
+    expect(innerEmit).toHaveBeenCalledWith('player:killed', expect.any(Object));
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/server/serialisation.test.js
+++ b/__tests__/server/serialisation.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+import { ServerGameState } from '../../core/ServerGameState.js';
+import { Player } from '../../entities/Player.js';
+import { Projectile } from '../../entities/Projectile.js';
+import { jest } from '@jest/globals';
+
+describe('ServerGameState serialization', () => {
+  test('round trip maintains data', () => {
+    jest.useFakeTimers();
+    const state = new ServerGameState(123);
+    globalThis.gameState = state;
+    const p = new Player(1, 2);
+    p.playerId = 'p1';
+    state.players.set('p1', p);
+    const pr = new Projectile(5, 5, 0, 'p1');
+    state.projectiles.set('proj1', pr);
+    state.frame = 42;
+    state.leaderboard.set('p1', { kills: 3, streak: 2 });
+
+    const obj = state.serialize();
+    const copy = ServerGameState.deserialize(JSON.parse(JSON.stringify(obj)));
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    expect(copy.frame).toBe(42);
+    expect(copy.players.get('p1').gridX).toBe(1);
+    expect(copy.projectiles.get('proj1').x).toBe(5);
+    expect(copy.leaderboard.get('p1').kills).toBe(3);
+  });
+});

--- a/core/Game.js
+++ b/core/Game.js
@@ -32,7 +32,6 @@ export class Game {
     }
 
     animate = () => {
-        this.gameState.update();
         this.updateCamera();
         this.renderer.render(this.gameState);
         requestAnimationFrame(this.animate);

--- a/core/GameRoom.js
+++ b/core/GameRoom.js
@@ -1,0 +1,183 @@
+import { ServerGameState } from './ServerGameState.js';
+import { Player } from '../entities/Player.js';
+import { Projectile } from '../entities/Projectile.js';
+import { collidesWithShield } from '../utils/collision.js';
+import { distanceSquared } from '../utils/math.js';
+
+export class GameRoom {
+  constructor({ io, roomId }) {
+    this.io = io;
+    this.roomId = roomId;
+    this.state = new ServerGameState();
+    this.sockets = new Map();
+    this.inputQueue = [];
+    this.lastPlayers = new Map();
+    this.lastProjectiles = new Map();
+    this.loop = this.loop.bind(this);
+  }
+
+  start() {
+    if (!this.interval) {
+      this.interval = setInterval(this.loop, 1000 / 60);
+    }
+  }
+
+  addSocket(socket) {
+    this.sockets.set(socket.id, socket);
+    socket.join(this.roomId);
+    const spawn = this.state.grid.getRandomSpawn();
+    const player = new Player(spawn.gx, spawn.gy);
+    player.playerId = socket.id;
+    this.state.players.set(socket.id, player);
+    this.state.leaderboard.set(socket.id, { kills: 0, streak: 0 });
+    socket.emit('init', { id: socket.id });
+  }
+
+  removeSocket(socket) {
+    this.sockets.delete(socket.id);
+    this.state.players.delete(socket.id);
+    this.state.leaderboard.delete(socket.id);
+  }
+
+  handleInput(socketId, input) {
+    this.inputQueue.push({ socketId, input });
+  }
+
+  broadcast(event, payload) {
+    this.io.to(this.roomId).emit(event, payload);
+  }
+
+  applyInputs() {
+    const queue = this.inputQueue;
+    this.inputQueue = [];
+    queue.forEach(({ socketId, input }) => {
+      const player = this.state.players.get(socketId);
+      if (!player) return;
+      switch (input.type) {
+        case 'move':
+          player.move(input.dir);
+          break;
+        case 'rotate':
+          player.rotate(input.dir);
+          break;
+        case 'interact': {
+          if (player.heldOrb) {
+            const proj = new Projectile(player.worldX, player.worldY, player.heading, player.playerId);
+            const id = `${socketId}-${Date.now()}`;
+            this.state.projectiles.set(id, proj);
+            player.heldOrb = false;
+          } else {
+            const tile = this.state.grid.getTileAt(player.gridX, player.gridY);
+            if (tile && tile.hasOrb) {
+              tile.hasOrb = false;
+              player.heldOrb = true;
+            }
+          }
+          break;
+        }
+      }
+    });
+  }
+
+  updateProjectiles() {
+    for (const [id, proj] of Array.from(this.state.projectiles.entries())) {
+      const expired = proj.update();
+      if (expired) {
+        this.state.projectiles.delete(id);
+      }
+    }
+  }
+
+  resolveCollisions() {
+    for (const [projId, proj] of Array.from(this.state.projectiles.entries())) {
+      for (const [pid, player] of this.state.players.entries()) {
+        if (proj.shooterId === pid) continue;
+        if (collidesWithShield(proj, player)) {
+          continue;
+        }
+        const cubeRadius = this.state.grid.getInnerSize() / 2;
+        const distSq = distanceSquared(proj.x, proj.y, player.worldX, player.worldY);
+        if (distSq <= cubeRadius * cubeRadius) {
+          const killer = this.state.leaderboard.get(proj.shooterId);
+          if (killer) {
+            killer.kills += 1;
+            killer.streak += 1;
+          }
+          const victim = this.state.leaderboard.get(pid);
+          if (victim) {
+            victim.streak = 0;
+          }
+          player.respawn();
+          this.broadcast('player:killed', {
+            killerId: proj.shooterId,
+            victimId: pid,
+            streak: killer ? killer.streak : 0,
+          });
+          this.state.projectiles.delete(projId);
+          break;
+        }
+      }
+    }
+  }
+
+  emitDelta() {
+    const playerDelta = [];
+   for (const [id, pl] of this.state.players.entries()) {
+     const last = this.lastPlayers.get(id);
+     if (!last || last.gridX !== pl.gridX || last.gridY !== pl.gridY || last.heading !== pl.heading || last.heldOrb !== pl.heldOrb) {
+       playerDelta.push([id, { gridX: pl.gridX, gridY: pl.gridY, heading: pl.heading, heldOrb: pl.heldOrb }]);
+     }
+   }
+    for (const id of this.lastPlayers.keys()) {
+      if (!this.state.players.has(id)) {
+        playerDelta.push([id, null]);
+      }
+    }
+    this.lastPlayers = new Map(
+      Array.from(this.state.players.entries()).map(([id, pl]) => [id, {
+        gridX: pl.gridX,
+        gridY: pl.gridY,
+        heading: pl.heading,
+        heldOrb: pl.heldOrb,
+      }])
+    );
+
+    const projectileDelta = [];
+    for (const [id, pr] of this.state.projectiles.entries()) {
+      const last = this.lastProjectiles.get(id);
+      if (!last || last.x !== pr.x || last.y !== pr.y || last.heading !== pr.heading) {
+        projectileDelta.push([id, { x: pr.x, y: pr.y, heading: pr.heading, shooterId: pr.shooterId }]);
+      }
+    }
+    for (const id of this.lastProjectiles.keys()) {
+      if (!this.state.projectiles.has(id)) {
+        projectileDelta.push([id, null]);
+      }
+    }
+    this.lastProjectiles = new Map(
+      Array.from(this.state.projectiles.entries()).map(([id, pr]) => [id, {
+        x: pr.x,
+        y: pr.y,
+        heading: pr.heading,
+        shooterId: pr.shooterId,
+      }])
+    );
+
+    if (playerDelta.length || projectileDelta.length) {
+      this.broadcast('state:update', { players: playerDelta, projectiles: projectileDelta, frame: this.state.frame });
+    }
+  }
+
+  loop() {
+    globalThis.gameState = this.state;
+    globalThis.sendProjectile = (proj) => {
+      const id = `p-${Date.now()}-${Math.random()}`;
+      this.state.projectiles.set(id, proj);
+    };
+    this.applyInputs();
+    this.updateProjectiles();
+    this.resolveCollisions();
+    this.state.frame += 1;
+    this.emitDelta();
+  }
+}

--- a/core/ServerGameState.js
+++ b/core/ServerGameState.js
@@ -1,0 +1,52 @@
+import { Grid } from '../entities/Grid.js';
+import { Player } from '../entities/Player.js';
+import { Projectile } from '../entities/Projectile.js';
+
+export class ServerGameState {
+  constructor(seed = Date.now()) {
+    this.grid = new Grid(4000, 200);
+    this.players = new Map();
+    this.projectiles = new Map();
+    this.frame = 0;
+    this.rngSeed = seed;
+    this.leaderboard = new Map();
+  }
+
+  serialize() {
+    return {
+      frame: this.frame,
+      rngSeed: this.rngSeed,
+      players: Array.from(this.players.entries()).map(([id, p]) => [id, {
+        gridX: p.gridX,
+        gridY: p.gridY,
+        heading: p.heading,
+        heldOrb: p.heldOrb,
+      }]),
+      projectiles: Array.from(this.projectiles.entries()).map(([id, pr]) => [id, {
+        x: pr.x,
+        y: pr.y,
+        heading: pr.heading,
+        shooterId: pr.shooterId,
+      }]),
+      leaderboard: Array.from(this.leaderboard.entries()),
+    };
+  }
+
+  static deserialize(obj) {
+    const state = new ServerGameState(obj.rngSeed);
+    state.frame = obj.frame;
+    obj.players.forEach(([id, data]) => {
+      const p = new Player(data.gridX, data.gridY);
+      p.playerId = id;
+      p.heading = data.heading;
+      p.heldOrb = data.heldOrb;
+      state.players.set(id, p);
+    });
+    obj.projectiles.forEach(([id, pr]) => {
+      const proj = new Projectile(pr.x, pr.y, pr.heading, pr.shooterId);
+      state.projectiles.set(id, proj);
+    });
+    state.leaderboard = new Map(obj.leaderboard);
+    return state;
+  }
+}

--- a/input/InputHandler.js
+++ b/input/InputHandler.js
@@ -17,26 +17,21 @@ export class InputHandler {
         switch (key) {
             case 'arrowup':
             case 'w':
-                this.gameState.player.move(1);
                 action = { type: 'move', dir: 1 };
                 break;
             case 'arrowdown':
             case 's':
-                this.gameState.player.move(-1);
                 action = { type: 'move', dir: -1 };
                 break;
             case 'arrowleft':
             case 'a':
-                this.gameState.player.rotate(-1);
                 action = { type: 'rotate', dir: -1 };
                 break;
             case 'arrowright':
             case 'd':
-                this.gameState.player.rotate(1);
                 action = { type: 'rotate', dir: 1 };
                 break;
             case ' ':
-                this.gameState.player.interact();
                 action = { type: 'interact' };
                 break;
         }


### PR DESCRIPTION
## Summary
- add `ServerGameState` for server-side authoritative state
- implement `GameRoom` that runs the game loop and emits deltas
- refactor `server.js` to route connections into rooms
- update client networking to send inputs and apply state deltas
- disable client-side game logic and input mutations
- document authoritative rooms and ROOM_CAP env var
- add server tests for kill logic and serialization

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_686c4f2d67e88326b7df3012cbd73e0a